### PR TITLE
Improve import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,12 @@ pull-models: ## Download models.
 crawl: MAX_DEPTH?=2
 crawl: URL?=https://app.readytensor.ai/hubs/ready_tensor_certifications
 crawl: ## Crawl a website.
-	docker compose exec knowledgebot /knowledgebot crawl "$(URL)" --max-depth=$(MAX_DEPTH)
+	docker compose exec knowledgebot /knowledgebot crawl "$(URL)" --max-depth=$(MAX_DEPTH) --url-regex="$(URL_REGEX)"
 
-crawl-wikipedia-futurama: MAX_DEPTH=1
+crawl-wikipedia-futurama: MAX_DEPTH?=2
+crawl-wikipedia-futurama: URL_REGEX=^https://en.wikipedia.org/wiki/([^:]+|[^:]:_.+)$
 crawl-wikipedia-futurama:
-	make crawl URL=https://en.wikipedia.org/wiki/Futurama MAX_DEPTH=$(MAX_DEPTH)
+	make crawl URL=https://en.wikipedia.org/wiki/Futurama MAX_DEPTH=$(MAX_DEPTH) URL_REGEX="$(URL_REGEX)"
 
 ##@ General
 

--- a/cmd/knowledgebot/crawl.go
+++ b/cmd/knowledgebot/crawl.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"regexp"
+
 	"github.com/mgoltzsche/knowledgebot/internal/importer/crawler"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +25,7 @@ func init() {
 	f := crawlCmd.Flags()
 
 	f.IntVar(&crawl.MaxDepth, "max-depth", crawl.MaxDepth, "Maximum crawl depth")
+	f.Var((*urlRegexFlag)(&crawl), "url-regex", "regex to filter URLs to crawl")
 	storeFactory.AddLLMFlags(f)
 	storeFactory.AddStoreFlags(f)
 
@@ -47,4 +50,29 @@ func crawlWebsite(cmd *cobra.Command, args []string) error {
 	}
 
 	return crawl.Crawl(cmd.Context(), args[0])
+}
+
+type urlRegexFlag crawler.Crawler
+
+func (f *urlRegexFlag) Set(s string) error {
+	r, err := regexp.Compile(s)
+	if err != nil {
+		return err
+	}
+
+	f.URLRegex = r
+
+	return nil
+}
+
+func (f *urlRegexFlag) Type() string {
+	return "regex"
+}
+
+func (f *urlRegexFlag) String() string {
+	if f.URLRegex == nil {
+		return ""
+	}
+
+	return f.URLRegex.String()
 }

--- a/cmd/knowledgebot/serve.go
+++ b/cmd/knowledgebot/serve.go
@@ -20,12 +20,11 @@ var (
 		RunE:    runServer,
 		PreRunE: preRunServer,
 	}
-	listenAddr     = ":8080"
-	scoreThreshold = 0.8
-	workflow       = &qna.QuestionAnswerWorkflow{
+	listenAddr = ":8080"
+	workflow   = &qna.QuestionAnswerWorkflow{
 		Temperature:    0.7,
 		MaxDocs:        15,
-		ScoreThreshold: 0.7,
+		ScoreThreshold: 0.5,
 	}
 	routes = server.Routes{
 		WebDir:   "/var/lib/knowledgebot/ui",
@@ -57,7 +56,7 @@ func init() {
 	f.StringVar(&routes.WebDir, "web-dir", routes.WebDir, "Path to the web UI directory")
 	f.Float64Var(&workflow.Temperature, "temperature", workflow.Temperature, "LLM temperature")
 	f.IntVar(&workflow.MaxDocs, "max-docs", workflow.MaxDocs, "Maximum number of document chunks to lookup from vector database")
-	f.Float64Var(&scoreThreshold, "score-threshold", scoreThreshold, "vector database lookup score threshold")
+	f.Float64Var(&workflow.ScoreThreshold, "score-threshold", workflow.ScoreThreshold, "vector database lookup score threshold")
 	llmFactory.AddLLMFlags(f)
 	storeFactory.AddStoreFlags(f)
 

--- a/cmd/knowledgebot/serve.go
+++ b/cmd/knowledgebot/serve.go
@@ -16,6 +16,7 @@ var (
 		Use:     "serve",
 		Short:   "Run the web server",
 		Long:    `Run the web server.`,
+		Args:    cobra.ExactArgs(0),
 		RunE:    runServer,
 		PreRunE: preRunServer,
 	}

--- a/internal/importer/crawler/crawler.go
+++ b/internal/importer/crawler/crawler.go
@@ -2,11 +2,14 @@ package crawler
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
@@ -17,9 +20,11 @@ import (
 )
 
 type Crawler struct {
-	MaxDepth int
-	URLRegex *regexp.Regexp
-	Sink     vectorstores.VectorStore
+	MaxDepth         int
+	URLRegex         *regexp.Regexp
+	Sink             vectorstores.VectorStore
+	mutex            sync.Mutex
+	knownChunkHashes map[string]struct{}
 }
 
 func (s *Crawler) Crawl(ctx context.Context, seedURL string) error {
@@ -69,7 +74,7 @@ func (s *Crawler) crawl(ctx context.Context, seedURL *url.URL, ch chan<- []schem
 	})
 
 	c.OnResponse(func(f *colly.Response) {
-		err := processHTML(ctx, f.Request.URL, string(f.Body), ch)
+		err := s.processHTML(ctx, f.Request.URL, string(f.Body), ch)
 		if err != nil {
 			log.Println("WARNING:", err)
 		}
@@ -85,7 +90,7 @@ func (s *Crawler) crawl(ctx context.Context, seedURL *url.URL, ch chan<- []schem
 	return ctx.Err()
 }
 
-func processHTML(ctx context.Context, url *url.URL, html string, ch chan<- []schema.Document) error {
+func (s *Crawler) processHTML(ctx context.Context, url *url.URL, html string, ch chan<- []schema.Document) error {
 	markdown, err := htmltomarkdown.ConvertString(html)
 	if err != nil {
 		return fmt.Errorf("html to markdown: %w", err)
@@ -100,27 +105,48 @@ func processHTML(ctx context.Context, url *url.URL, html string, ch chan<- []sch
 
 	log.Printf("scraped %d chunks from %s", len(chunks), url)
 
-	if len(chunks) > 0 {
-		docs := make([]schema.Document, len(chunks))
+	docs := make([]schema.Document, 0, len(chunks))
 
-		for i, chunk := range chunks {
-			docs[i] = schema.Document{
-				PageContent: chunk,
-				Metadata: map[string]any{
-					// TODO: deduplicate URLs:
-					// * save final redirect location instead of redirect source URL (to get rid of single-character URLs pointing to list of all Futurama characters URL).
-					// * ignore URLs that don't follow the scheme https://en.wikipedia.org/wiki/<ARTICLE>
-					// * (maybe keep track of content hashes and ignore duplicate contents)
-					"url":   url.String(),
-					"title": deriveTitle(markdown, url),
-				},
-			}
+	for _, chunk := range chunks {
+		if s.knownChunk(chunk) {
+			continue
 		}
 
+		docs = append(docs, schema.Document{
+			PageContent: chunk,
+			Metadata: map[string]any{
+				"url":   url.String(),
+				"title": deriveTitle(markdown, url),
+			},
+		})
+	}
+
+	if len(docs) > 0 {
 		ch <- docs
 	}
 
 	return nil
+}
+
+func (s *Crawler) knownChunk(chunk string) bool {
+	h := sha256.New()
+	_, _ = h.Write([]byte(chunk))
+	b := h.Sum(nil)
+	key := hex.EncodeToString(b)
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.knownChunkHashes == nil {
+		s.knownChunkHashes = map[string]struct{}{}
+	}
+
+	_, known := s.knownChunkHashes[key]
+	if !known {
+		s.knownChunkHashes[key] = struct{}{}
+	}
+
+	return known
 }
 
 func deriveTitle(markdown string, u *url.URL) string {

--- a/internal/qna/qnaworkflow.go
+++ b/internal/qna/qnaworkflow.go
@@ -17,7 +17,7 @@ type QuestionAnswerWorkflow struct {
 	Temperature    float64
 	Store          vectorstores.VectorStore
 	MaxDocs        int
-	ScoreThreshold float32
+	ScoreThreshold float64
 }
 
 type ResponseChunk struct {
@@ -39,7 +39,7 @@ type Snippet struct {
 }
 
 func (w *QuestionAnswerWorkflow) Answer(ctx context.Context, question string) (<-chan ResponseChunk, error) {
-	docs, err := w.Store.SimilaritySearch(ctx, question, w.MaxDocs, vectorstores.WithScoreThreshold(w.ScoreThreshold))
+	docs, err := w.Store.SimilaritySearch(ctx, question, w.MaxDocs, vectorstores.WithScoreThreshold(float32(w.ScoreThreshold)))
 	if err != nil {
 		return nil, fmt.Errorf("query knowledge base: %w", err)
 	}


### PR DESCRIPTION
Closes #1:
* Add `--url-regex` CLI option as crawler filter and use it to crawl only regular wikipedia article URLs.
* Deduplicate chunks on import by mapping and comparing their hashes. This is to more efficiently use the LLM context size and speed up requests.

Additional API improvement:
* Decrease score threshold from 0.7 to 0.5 in order to get more matches.