### PR TITLE
feat: make log level configurable, use log/slog

### DIFF
--- a/cmd/knowledgebot/main.go
+++ b/cmd/knowledgebot/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
+	"os"
 	"os/signal"
 	"syscall"
 )
@@ -13,6 +14,7 @@ func main() {
 
 	err := rootCmd.ExecuteContext(ctx)
 	if err != nil {
-		log.Fatal("FATAL: ", err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/cmd/knowledgebot/serve.go
+++ b/cmd/knowledgebot/serve.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 
@@ -101,11 +101,11 @@ func runServer(cmd *cobra.Command, args []string) error {
 		<-ctx.Done()
 		err := srv.Shutdown(ctx)
 		if err != nil {
-			log.Println("ERROR: failed to shutdown server:", err)
+			slog.Error("failed to shutdown server: " + err.Error())
 		}
 	}()
 
-	log.Println("listening on", srv.Addr)
+	slog.Info("listening on " + srv.Addr)
 
 	err := srv.ListenAndServe()
 	if err == http.ErrServerClosed {

--- a/internal/qdrantutils/collection.go
+++ b/internal/qdrantutils/collection.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -37,7 +37,7 @@ func CreateQdrantCollectionIfNotExist(ctx context.Context, qdrantURL, collection
 	}
 
 	if resp.StatusCode == http.StatusOK {
-		log.Printf("created qdrant collection %q", collection)
+		slog.Info("created qdrant collection " + collection)
 		return nil
 	}
 

--- a/internal/qna/qnaworkflow.go
+++ b/internal/qna/qnaworkflow.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/tmc/langchaingo/llms"
@@ -82,7 +82,7 @@ func (w *QuestionAnswerWorkflow) Answer(ctx context.Context, question string) (<
 		return nil, err
 	}
 
-	log.Println("Requesting LLM answer for prompt:\n  ", strings.ReplaceAll(prompt, "\n", "\n  "))
+	slog.Info("Requesting LLM answer for prompt:" + strings.ReplaceAll("\n"+prompt, "\n", "\n  "))
 
 	go func() {
 		defer close(ch)
@@ -124,13 +124,13 @@ func searchResultsToSourceRefs(docs []schema.Document) []SourceReference {
 	for _, doc := range docs {
 		urlKey, ok := doc.Metadata["url"].(string)
 		if !ok {
-			log.Println("WARNING: vectordb search result doc does not specify 'url' metadata key")
+			slog.Warn("vectordb search result doc does not specify 'url' metadata key")
 			continue
 		}
 
 		title, ok := doc.Metadata["title"].(string)
 		if !ok {
-			log.Println("WARNING: vectordb search result doc does not specify 'title' metadata key")
+			slog.Warn("vectordb search result doc does not specify 'title' metadata key")
 			continue
 		}
 

--- a/internal/server/qnahandler.go
+++ b/internal/server/qnahandler.go
@@ -3,7 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/mgoltzsche/knowledgebot/internal/qna"
@@ -15,7 +15,7 @@ func newQuestionAnswerHandler(ai *qna.QuestionAnswerWorkflow) http.Handler {
 		if question == "" {
 			err := req.ParseForm()
 			if err != nil {
-				log.Println("WARNING: parse form data:", err)
+				slog.Warn("parse form data: " + err.Error())
 			}
 
 			question = req.Form.Get("q")
@@ -40,7 +40,7 @@ func newQuestionAnswerHandler(ai *qna.QuestionAnswerWorkflow) http.Handler {
 
 			data, err := json.Marshal(chunk)
 			if err != nil {
-				log.Println("ERROR: failed to marshal chunk:", err)
+				slog.Error("failed to marshal chunk: " + err.Error())
 				continue
 			}
 


### PR DESCRIPTION
* use `log/slog` package instead of `log`.
* turn irritating crawler warnings into debug logs (not visible by default).
* add CLI option to configure the log level.